### PR TITLE
Add simplified TFT alias environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-"# Rendu" 
-"# Rendu" 
+# Rendu
+
+This repository provides a minimal MuZero implementation and a simplified Teamfight Tactics environment.
+
+- `tft_alias.py` implements a lightweight TFT-like environment with basic shop, board and synergy mechanics.
+- `muzero_tft.py` contains a MuZero agent that interacts with this alias environment for demonstration.
+
+Run a small training loop with:
+
+```bash
+python muzero_tft.py
+```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Rendu
 
-This repository provides a minimal MuZero implementation and a simplified Teamfight Tactics environment.
+This repository provides a minimal MuZero implementation, a simplified Teamfight Tactics environment, and example cryptocurrency backtesting strategies.
 
 - `tft_alias.py` implements a lightweight TFT-like environment with basic shop, board and synergy mechanics.
 - `muzero_tft.py` contains a MuZero agent that interacts with this alias environment for demonstration.
+- `backtest.py` fetches market data from Binance and runs simple BTC/ETC strategies.
 
-Run a small training loop with:
+Run a small MuZero training loop with:
 
 ```bash
 python muzero_tft.py
+```
+
+Backtest a strategy (e.g. EMA breakout) with:
+
+```bash
+python backtest.py --strategy breakout_ema_volume --symbol BTCUSDT --interval 30m
 ```

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,75 @@
+import argparse
+import requests
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from breakout_ema_volume import ema_breakout_volume_strategy
+from rsi_reversal import rsi_reversal_strategy
+from vwap_mean_reversion import vwap_mean_reversion_strategy
+from breakout_fakeout import breakout_fakeout_strategy
+from ema_pullback import ema_pullback_strategy
+
+
+STRATEGIES = {
+    "breakout_ema_volume": ema_breakout_volume_strategy,
+    "rsi_reversal": rsi_reversal_strategy,
+    "vwap_mean_reversion": vwap_mean_reversion_strategy,
+    "breakout_fakeout": breakout_fakeout_strategy,
+    "ema_pullback": ema_pullback_strategy,
+}
+
+
+def fetch_binance_klines(symbol: str, interval: str, limit: int = 500):
+    url = "https://api.binance.com/api/v3/klines"
+    params = {"symbol": symbol, "interval": interval, "limit": limit}
+    response = requests.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    cols = [
+        "open_time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "close_time",
+        "qav",
+        "num_trades",
+        "taker_base",
+        "taker_quote",
+        "ignore",
+    ]
+    df = pd.DataFrame(data, columns=cols)
+    df = df.astype(
+        {
+            "open": "float",
+            "high": "float",
+            "low": "float",
+            "close": "float",
+            "volume": "float",
+        }
+    )
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backtest strategies on Binance data")
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--interval", default="15m")
+    parser.add_argument("--strategy", choices=list(STRATEGIES.keys()), required=True)
+    args = parser.parse_args()
+
+    df = fetch_binance_klines(args.symbol, args.interval)
+    strategy_fn = STRATEGIES[args.strategy]
+    curve = strategy_fn(df)
+
+    plt.plot(curve.index, curve.values)
+    plt.title(f"{args.strategy} on {args.symbol}")
+    plt.xlabel("Steps")
+    plt.ylabel("PnL")
+    plt.grid(True)
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/breakout_ema_volume.py
+++ b/breakout_ema_volume.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+
+def ema_breakout_volume_strategy(df):
+    """Breakout strategy using EMA20/50 and volume spike."""
+    df = df.copy()
+    df['ema20'] = df['close'].ewm(span=20).mean()
+    df['ema50'] = df['close'].ewm(span=50).mean()
+    df['vol_avg20'] = df['volume'].rolling(20).mean()
+
+    position = None
+    entry_price = 0.0
+    stop = 0.0
+    target = 0.0
+    equity_curve = []
+    pnl = 0.0
+
+    for i in range(50, len(df)):
+        price = df['close'].iloc[i]
+        high_range = df['high'].iloc[i-20:i].max()
+        low_range = df['low'].iloc[i-20:i].min()
+        volume = df['volume'].iloc[i]
+        cond_breakout = (
+            price > high_range and
+            price > df['ema20'].iloc[i] and
+            price > df['ema50'].iloc[i] and
+            volume > df['vol_avg20'].iloc[i]
+        )
+        if position is None and cond_breakout:
+            position = 'long'
+            entry_price = price
+            stop = low_range
+            risk = entry_price - stop
+            target = entry_price + 1.5 * risk
+        elif position == 'long':
+            if df['low'].iloc[i] <= stop:
+                pnl += stop - entry_price
+                position = None
+            elif price >= target:
+                pnl += target - entry_price
+                position = None
+        equity_curve.append(pnl)
+    return pd.Series(equity_curve)

--- a/breakout_fakeout.py
+++ b/breakout_fakeout.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+
+def breakout_fakeout_strategy(df):
+    """Breakout fakeout (liquidity trap) strategy."""
+    df = df.copy()
+    equity_curve = []
+    pnl = 0.0
+    position = None
+    entry_price = 0.0
+    stop = 0.0
+    target = 0.0
+
+    for i in range(20, len(df)):
+        high_range = df['high'].iloc[i-20:i].max()
+        low_range = df['low'].iloc[i-20:i].min()
+        close = df['close'].iloc[i]
+        high = df['high'].iloc[i]
+        low = df['low'].iloc[i]
+        if position is None:
+            if high > high_range and close < high_range:
+                position = 'short'
+                entry_price = close
+                stop = high
+                target = (high_range + low_range) / 2
+            elif low < low_range and close > low_range:
+                position = 'long'
+                entry_price = close
+                stop = low
+                target = (high_range + low_range) / 2
+        elif position == 'long':
+            if low <= stop:
+                pnl += stop - entry_price
+                position = None
+            elif close >= target:
+                pnl += target - entry_price
+                position = None
+        elif position == 'short':
+            if high >= stop:
+                pnl += entry_price - stop
+                position = None
+            elif close <= target:
+                pnl += entry_price - target
+                position = None
+        equity_curve.append(pnl)
+    return pd.Series(equity_curve)

--- a/ema_pullback.py
+++ b/ema_pullback.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+
+def ema_pullback_strategy(df):
+    """EMA pullback trend trading strategy."""
+    df = df.copy()
+    df['ema9'] = df['close'].ewm(span=9).mean()
+    df['ema21'] = df['close'].ewm(span=21).mean()
+
+    position = None
+    entry_price = 0.0
+    stop = 0.0
+    target = 0.0
+    equity_curve = []
+    pnl = 0.0
+
+    for i in range(21, len(df)):
+        price = df['close'].iloc[i]
+        trend_up = df['ema9'].iloc[i] > df['ema21'].iloc[i]
+        pullback = df['low'].iloc[i] <= df['ema21'].iloc[i]
+        bullish = df['close'].iloc[i] > df['open'].iloc[i]
+        if position is None and trend_up and pullback and bullish:
+            position = 'long'
+            entry_price = price
+            stop = df['ema21'].iloc[i]
+            risk = entry_price - stop
+            target = entry_price + 2 * risk
+        elif position == 'long':
+            if df['low'].iloc[i] <= stop:
+                pnl += stop - entry_price
+                position = None
+            elif price >= target:
+                pnl += target - entry_price
+                position = None
+        equity_curve.append(pnl)
+    return pd.Series(equity_curve)

--- a/muzero_tft.py
+++ b/muzero_tft.py
@@ -1,0 +1,145 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from collections import namedtuple
+import random
+
+from tft_alias import TFTAliasEnv
+
+# Environment factory
+# Uses a simplified TFT alias environment defined in tft_alias.py
+def make_env():
+    return TFTAliasEnv()
+
+# MuZero network components
+class RepresentationNetwork(nn.Module):
+    def __init__(self, obs_dim, hidden_dim):
+        super().__init__()
+        self.fc = nn.Linear(obs_dim, hidden_dim)
+
+    def forward(self, x):
+        return torch.tanh(self.fc(x))
+
+class DynamicsNetwork(nn.Module):
+    def __init__(self, hidden_dim, action_dim):
+        super().__init__()
+        self.fc_action = nn.Linear(action_dim, hidden_dim)
+        self.fc_hidden = nn.Linear(hidden_dim, hidden_dim)
+        self.reward_head = nn.Linear(hidden_dim, 1)
+
+    def forward(self, hidden, action_one_hot):
+        x = torch.tanh(self.fc_hidden(hidden) + self.fc_action(action_one_hot))
+        reward = self.reward_head(x)
+        return x, reward
+
+class PredictionNetwork(nn.Module):
+    def __init__(self, hidden_dim, action_dim):
+        super().__init__()
+        self.policy_head = nn.Linear(hidden_dim, action_dim)
+        self.value_head = nn.Linear(hidden_dim, 1)
+
+    def forward(self, hidden):
+        policy_logits = self.policy_head(hidden)
+        value = self.value_head(hidden)
+        return policy_logits, value
+
+class MuZeroNet(nn.Module):
+    def __init__(self, obs_dim, hidden_dim, action_dim):
+        super().__init__()
+        self.representation = RepresentationNetwork(obs_dim, hidden_dim)
+        self.dynamics = DynamicsNetwork(hidden_dim, action_dim)
+        self.prediction = PredictionNetwork(hidden_dim, action_dim)
+        self.action_dim = action_dim
+
+    def initial_inference(self, obs):
+        hidden = self.representation(obs)
+        policy_logits, value = self.prediction(hidden)
+        reward = torch.zeros(1)
+        return hidden, policy_logits, value, reward
+
+    def recurrent_inference(self, hidden, action):
+        action_one_hot = torch.nn.functional.one_hot(action, num_classes=self.action_dim).float()
+        next_hidden, reward = self.dynamics(hidden, action_one_hot)
+        policy_logits, value = self.prediction(next_hidden)
+        return next_hidden, policy_logits, value, reward
+
+# Storage for experience (simplified)
+Transition = namedtuple('Transition', 'obs action reward next_obs done')
+
+class ReplayBuffer:
+    def __init__(self, capacity=10000):
+        self.buffer = []
+        self.capacity = capacity
+
+    def push(self, *args):
+        if len(self.buffer) >= self.capacity:
+            self.buffer.pop(0)
+        self.buffer.append(Transition(*args))
+
+    def sample(self, batch_size):
+        return random.sample(self.buffer, batch_size)
+
+    def __len__(self):
+        return len(self.buffer)
+
+# Simplified training loop skeleton
+class MuZeroAgent:
+    def __init__(self, obs_dim, action_dim, hidden_dim=128, lr=1e-3):
+        self.net = MuZeroNet(obs_dim, hidden_dim, action_dim)
+        self.optimizer = optim.Adam(self.net.parameters(), lr=lr)
+        self.replay_buffer = ReplayBuffer()
+        self.batch_size = 32
+
+    def select_action(self, obs):
+        with torch.no_grad():
+            _, policy_logits, _, _ = self.net.initial_inference(obs)
+            action = torch.distributions.Categorical(logits=policy_logits).sample()
+        return action.item()
+
+    def store_transition(self, obs, action, reward, next_obs, done):
+        self.replay_buffer.push(obs, action, reward, next_obs, done)
+
+    def update(self):
+        if len(self.replay_buffer) < self.batch_size:
+            return
+        transitions = self.replay_buffer.sample(self.batch_size)
+        batch = Transition(*zip(*transitions))
+        obs_batch = torch.stack(batch.obs)
+        action_batch = torch.tensor(batch.action)
+        reward_batch = torch.tensor(batch.reward)
+        next_obs_batch = torch.stack(batch.next_obs)
+        done_batch = torch.tensor(batch.done, dtype=torch.float32)
+
+        hidden, policy_logits, value, reward_pred = self.net.initial_inference(obs_batch)
+        value_target = reward_batch + (1 - done_batch) * 0.99  # bootstrap with discount
+
+        policy_loss = nn.functional.cross_entropy(policy_logits, action_batch)
+        value_loss = nn.functional.mse_loss(value.squeeze(), value_target)
+        reward_loss = nn.functional.mse_loss(reward_pred.squeeze(), reward_batch)
+        loss = policy_loss + value_loss + reward_loss
+
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+        return loss.item()
+
+def train(num_episodes=10):
+    env = make_env()
+    agent = MuZeroAgent(obs_dim=env.observation_space.numel(), action_dim=env.action_space)
+
+    for episode in range(num_episodes):
+        obs = env.reset()
+        done = False
+        episode_reward = 0
+        while not done:
+            action = agent.select_action(obs)
+            next_obs, reward, done, _ = env.step(action)
+            agent.store_transition(obs, action, reward, next_obs, done)
+            loss = agent.update()
+            obs = next_obs
+            episode_reward += reward
+        print(f"Episode {episode}: reward {episode_reward:.2f}")
+
+if __name__ == "__main__":
+    train()

--- a/rsi_reversal.py
+++ b/rsi_reversal.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+
+def rsi_reversal_strategy(df):
+    """RSI reversal strategy using RSI14."""
+    df = df.copy()
+    delta = df['close'].diff()
+    gain = (delta.where(delta > 0, 0)).ewm(alpha=1/14, adjust=False).mean()
+    loss = (-delta.where(delta < 0, 0)).ewm(alpha=1/14, adjust=False).mean()
+    rs = gain / loss
+    df['rsi'] = 100 - 100 / (1 + rs)
+
+    position = None
+    entry_price = 0.0
+    stop = 0.0
+    target = 0.0
+    equity_curve = []
+    pnl = 0.0
+
+    for i in range(15, len(df)):
+        price = df['close'].iloc[i]
+        rsi = df['rsi'].iloc[i]
+        candle_bull = df['close'].iloc[i] > df['open'].iloc[i]
+        candle_bear = df['close'].iloc[i] < df['open'].iloc[i]
+        recent_low = df['low'].iloc[i-5:i+1].min()
+        if position is None and rsi < 25 and candle_bull:
+            position = 'long'
+            entry_price = price
+            stop = recent_low
+            risk = entry_price - stop
+            target = entry_price + 2 * risk
+        elif position == 'long':
+            if price <= stop:
+                pnl += stop - entry_price
+                position = None
+            elif rsi > 75 and candle_bear:
+                pnl += price - entry_price
+                position = None
+            elif price >= target:
+                pnl += target - entry_price
+                position = None
+        equity_curve.append(pnl)
+    return pd.Series(equity_curve)

--- a/tft_alias.py
+++ b/tft_alias.py
@@ -1,0 +1,60 @@
+import random
+import torch
+
+class TFTAliasEnv:
+    """A simplified Teamfight Tactics environment."""
+    def __init__(self, board_size=3, shop_size=3, unit_types=5, max_turns=20):
+        self.board_size = board_size
+        self.shop_size = shop_size
+        self.unit_types = unit_types
+        self.max_turns = max_turns
+        self.action_space = 4  # buy, reroll, sell, end turn
+        obs_len = board_size + shop_size + 1  # board + shop + gold
+        self.observation_space = torch.zeros(obs_len)
+        self.reset()
+
+    def reset(self):
+        self.turns = 0
+        self.gold = 10
+        self.board = [-1] * self.board_size
+        self.shop = [self._random_unit() for _ in range(self.shop_size)]
+        return self._get_obs()
+
+    def _random_unit(self):
+        return random.randint(0, self.unit_types - 1)
+
+    def _get_obs(self):
+        board = [u if u >= 0 else self.unit_types for u in self.board]
+        obs = board + self.shop + [self.gold]
+        return torch.tensor(obs, dtype=torch.float32)
+
+    def _synergy_reward(self):
+        counts = {}
+        for u in self.board:
+            if u >= 0:
+                counts[u] = counts.get(u, 0) + 1
+        return float(sum(c * c for c in counts.values()))
+
+    def step(self, action):
+        reward = 0.0
+        if action == 0:  # buy first shop unit
+            if self.gold >= 2 and -1 in self.board:
+                slot = self.board.index(-1)
+                self.board[slot] = self.shop[0]
+                self.gold -= 2
+                self.shop[0] = self._random_unit()
+        elif action == 1:  # reroll shop
+            if self.gold >= 1:
+                self.gold -= 1
+                self.shop = [self._random_unit() for _ in range(self.shop_size)]
+        elif action == 2:  # sell first board unit
+            if self.board[0] != -1:
+                self.gold += 1
+                self.board[0] = -1
+        elif action == 3:  # end turn and gain reward based on synergies
+            reward = self._synergy_reward()
+            self.gold += 5
+        self.turns += 1
+        done = self.turns >= self.max_turns
+        obs = self._get_obs()
+        return obs, reward, done, {}

--- a/vwap_mean_reversion.py
+++ b/vwap_mean_reversion.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+
+def vwap_mean_reversion_strategy(df):
+    """VWAP mean reversion strategy."""
+    df = df.copy()
+    cumulative_vol = df['volume'].cumsum()
+    cumulative_price_vol = (df['close'] * df['volume']).cumsum()
+    df['vwap'] = cumulative_price_vol / cumulative_vol
+
+    position = None
+    entry_price = 0.0
+    stop = 0.0
+    equity_curve = []
+    pnl = 0.0
+
+    for i in range(1, len(df)):
+        price = df['close'].iloc[i]
+        vwap = df['vwap'].iloc[i]
+        prev_vol = df['volume'].iloc[i-1]
+        vol_drop = df['volume'].iloc[i] < prev_vol
+        if position is None:
+            if price > vwap * 1.02 and vol_drop:
+                position = 'short'
+                entry_price = price
+                stop = price * 1.015
+            elif price < vwap * 0.98:
+                position = 'long'
+                entry_price = price
+                stop = price * 0.985
+        elif position == 'long':
+            if price >= vwap:
+                pnl += price - entry_price
+                position = None
+            elif price <= stop:
+                pnl += stop - entry_price
+                position = None
+        elif position == 'short':
+            if price <= vwap:
+                pnl += entry_price - price
+                position = None
+            elif price >= stop:
+                pnl += entry_price - stop
+                position = None
+        equity_curve.append(pnl)
+    return pd.Series(equity_curve)


### PR DESCRIPTION
## Summary
- create `tft_alias.py` implementing a lightweight Teamfight Tactics alias environment
- integrate `TFTAliasEnv` into `muzero_tft.py`
- document running the MuZero demo in `README.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684184700750832295821c38200e4d1c